### PR TITLE
update health actuator component property name

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -425,7 +425,7 @@ For example:
 
 [source,json]
 ----
-"quickfixjserver": {
+"quickfixjServerSession": {
     "status": "DOWN",
     "details": {
         "FIXT.1.1:BANZAI->EXEC1": "LoggedOn",
@@ -839,7 +839,7 @@ For example:
 
 [source,json]
 ----
-"quickfixjclient": {
+"quickfixjClientSession": {
     "status": "DOWN",
     "details": {
         "FIXT.1.1:BANZAI->EXEC1": "LoggedOn",


### PR DESCRIPTION
## Purpose

<img width="564" alt="image" src="https://github.com/ChoiJunsik/quickfixj-spring-boot-starter-contribution/assets/26922008/2f2fea3e-f973-4c28-a601-56eb18c13964">


The default behavior of [HealthContributorNameFactory](https://github.com/spring-projects/spring-boot/blob/4fd0e29cc8719bda72e0e67c2392fd48e7b4009d/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/HealthContributorNameFactory.java#L29) results in the prefix of the bean name becoming the name of the health component property.

So I'd like to change the component names described in README.